### PR TITLE
Be/main/jongmlee spring lv3

### DIFF
--- a/v1/backend/SPRING_LV_3_김영한_이동진_그리고/build.gradle
+++ b/v1/backend/SPRING_LV_3_김영한_이동진_그리고/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 }
 
 tasks.named('test') {

--- a/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/MovieController.java
+++ b/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/MovieController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,8 +20,8 @@ public class MovieController {
 		return movieService.getAllMovies();
 	}
 
-	@PostMapping
-	public Movie createMovie(MovieCreateRequestDto dto) {
+	@PostMapping("/movies")
+	public Movie createMovie(@RequestBody MovieCreateRequestDto dto) {
 		return movieService.createMovie(dto);
 	}
 }

--- a/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/MovieController.java
+++ b/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/MovieController.java
@@ -2,22 +2,19 @@ package com.example.dongglee;
 
 import com.example.dongglee.domain.Movie;
 import com.example.dongglee.dto.MovieCreateRequestDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
-@RequestMapping("/movies")
 @RequiredArgsConstructor
 public class MovieController {
 
 	private final MovieService movieService;
 
-	@GetMapping
+	@GetMapping("/movies")
 	public List<Movie> getMovie() {
 		return movieService.getAllMovies();
 	}

--- a/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/MovieRepository.java
+++ b/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/MovieRepository.java
@@ -1,13 +1,10 @@
 package com.example.dongglee;
 
 import com.example.dongglee.domain.Movie;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface MovieRepository {
-	List<Movie> findAll();
+public interface MovieRepository extends JpaRepository<Movie, Long> {
 
-	Movie save(Movie movie);
 }

--- a/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/domain/Movie.java
+++ b/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/domain/Movie.java
@@ -1,15 +1,30 @@
 package com.example.dongglee.domain;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Movie {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
 	private String director;
+
 	private String title;
+
 	private LocalDateTime filmedAt;
 }

--- a/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/dto/MovieCreateRequestDto.java
+++ b/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/java/com/example/dongglee/dto/MovieCreateRequestDto.java
@@ -1,11 +1,11 @@
 package com.example.dongglee.dto;
 
-import lombok.Getter;
-
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Getter
 public class MovieCreateRequestDto {
+
 	private String title;
 	private String director;
 	private LocalDateTime filmedAt;

--- a/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/resources/application.yml
+++ b/v1/backend/SPRING_LV_3_김영한_이동진_그리고/src/main/resources/application.yml
@@ -1,10 +1,14 @@
 spring:
   datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
     url: jdbc:mariadb://localhost:3306/test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
     password: example
+    driver-class-name: org.mariadb.jdbc.Driver
 
   jpa:
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true #콘솔에 로그가 나옴
+        format_sql: true #이쁘게 해줌


### PR DESCRIPTION
드디어 끝인가요!!!!! 빨리 빨리 했어야 하는데 죄송함다..

## Dto에 기본생성자만 있어도 역직렬화를 통한 객체 생성이 가능한 이유?
- @RequestBody를 쓰면 Jackson 라이브러리가 Json데이터를 역직렬화 해서 객체가 생성된다.
- 그러니 해당 객체에는 @Setter 혹은 @AllArgumentsConstructor가 필요할 줄 알았지만 없어도 문제없이 동작한다. 아니 어떻게 ??!!
- 이유는 Jackson 이 @Setter가 없으면 리플렉션을 사용해 필드에 직접 값에 접근할 수 있기 때문이다. 
- Jackson은 spring-boot-starter-web 의존성에 포함되어 있다.

## Jpa를 사용할때 Entity에 기본생성자가 있어야 하는 이유?
- Jpa는 DB에서 조회한 객체를 생성할때 리플렉션을 사용한다.
- 객체를 생성할 때 최소한 기본 생성자를 호출할 수 있어야 한다.
- 그렇다고 기본 생성자를 public으로 열 필요는 없다. protected로 해도 가능하다.
- LazyLoading을 구현할때도 프록시 객체에 리플렉션이 사용된다. 